### PR TITLE
Fix test on STDOUT output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ before_script:
   - "git config --global user.email 'you@example.com'"
   - "git config --global user.name 'Your Name'"
 perl:
-  - 5.10
-  - 5.12
-  - 5.14
-  - 5.16
-  - 5.18
-  - 5.20
-  - 5.22
-  - 5.24
+  - "5.10"
+  - "5.12"
+  - "5.14"
+  - "5.16"
+  - "5.18"
+  - "5.20"
+  - "5.22"
+  - "5.24"
 before_install:
   cpanm -n Devel::Cover::Report::Coveralls
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ perl:
   - 5.14
   - 5.16
   - 5.18
+  - 5.20
+  - 5.22
+  - 5.24
 before_install:
   cpanm -n Devel::Cover::Report::Coveralls
 script:

--- a/t/01_cpan-uploader-interface.t
+++ b/t/01_cpan-uploader-interface.t
@@ -6,7 +6,6 @@ use Plack::Test;
 use File::Temp;
 use File::Spec;
 use HTTP::Request::Common;
-use Test::Output;
 
 use OrePAN2::Server::CLI;
 
@@ -20,16 +19,13 @@ test_psgi
         my $cb = shift;
 
         subtest 'CPAN::Uploader interface' => sub {
-            my $res;
-            stdout_like {
-                $res = $cb->(POST "http://localhost/authenquery",
-                    Content_Type => 'form-data',
-                    Content      => +[
-                        HIDDENNAME                  => 'hirobanex',
-                        pause99_add_uri_httpupload  => ["./t/$mock_tar_name"]
-                    ],
-                );
-            } qr/Wrote/,'orepan inject ?';
+            my $res = $cb->(POST "http://localhost/authenquery",
+                Content_Type => 'form-data',
+                Content      => +[
+                    HIDDENNAME                  => 'hirobanex',
+                    pause99_add_uri_httpupload  => ["./t/$mock_tar_name"]
+                ],
+            );
 
             is $res->code, 200, 'success request ?';
             ok -f File::Spec->catfile($dir, qw/modules 02packages.details.txt.gz/), 'is there 02packages.details.txt.gz ?';


### PR DESCRIPTION
Remove a failing assertion on STDOUT upon injection since printing to STDOUT has been removed from OrePAN2::Injector as of OrePAN2 version 0.17.

FYR: https://github.com/tokuhirom/OrePAN2/commit/416d29cd1ab729bde8f62c9ef5d43f42fef24d1e#diff-6a28830da3615032588599748ea6b9c0
